### PR TITLE
fix: typo in param - "disable_video_tream"

### DIFF
--- a/twelvelabs/resources/task.py
+++ b/twelvelabs/resources/task.py
@@ -114,7 +114,7 @@ class Task(APIResource):
             "video_url": url,
             "transcription_url": transcription_url,
             "language": language,
-            "disable_video_tream": disable_video_stream,
+            "disable_video_stream": disable_video_stream,
         }
 
         files = {}


### PR DESCRIPTION
Typo in param name caused error when setting `disable_video_stream` on call to `Task.create()`.