### PR TITLE
fix: field types of ClassifyClip

### DIFF
--- a/twelvelabs/models/classify.py
+++ b/twelvelabs/models/classify.py
@@ -25,8 +25,8 @@ class ClassifyDetailedScore(BaseModel):
 
 
 class ClassifyClip(BaseModel):
-    start: int
-    end: int
+    start: float
+    end: float
     score: float
     option: str
     prompt: str


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

Fixed field types of ClassifyClip; int to float.
When calling classify methods with `include_clips=True`, it throws Pydantic validation error.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
