### PR TITLE
feat: add stream processing and support in open-ended text

### DIFF
--- a/examples/generate.py
+++ b/examples/generate.py
@@ -1,5 +1,4 @@
 import os
-
 import _context
 from twelvelabs import TwelveLabs
 
@@ -10,32 +9,36 @@ assert (
 ), "Your API key should be stored in an environment variable named API_KEY."
 
 with TwelveLabs(API_KEY) as client:
-    index = client.index.retrieve("<YOUR_INDEX_ID>")
-    videos = client.index.video.list(index.id)
-    if len(videos) == 0:
-        print(f"No videos in index {index.id}, exit")
-        exit()
-    video = videos[0]
+    video_id = "<YOUR_VIDEO_ID>"
 
-    gist = client.generate.gist(video.id, ["title"])
+    gist = client.generate.gist(video_id, ["title"])
     print(f"Gist: title={gist.title} topics={gist.topics} hashtags={gist.hashtags}")
 
-    res = client.generate.summarize(video.id, "summary")
+    res = client.generate.summarize(video_id, "summary")
     print(f"Summary: {res.summary}")
 
     print("Chapters:")
-    res = client.generate.summarize(video.id, "chapter")
+    res = client.generate.summarize(video_id, "chapter")
     for chapter in res.chapters:
         print(
             f"  chapter_number={chapter.chapter_number} chapter_title={chapter.chapter_title} chapter_summary={chapter.chapter_summary} start={chapter.start} end={chapter.end}"
         )
 
     print("Highlights:")
-    res = client.generate.summarize(video.id, "highlight")
+    res = client.generate.summarize(video_id, "highlight")
     for highlight in res.highlights:
         print(
             f"  highlight={highlight.highlight} start={highlight.start} end={highlight.end}"
         )
 
-    res = client.generate.text(video.id, "What happened?")
+    res = client.generate.text(video_id, "What happened?")
     print(f"Open-ended Text: {res.data}")
+
+    text_stream = client.generate.text_stream(
+        video_id=video_id, prompt="What happened?"
+    )
+
+    for text in text_stream:
+        print(text)
+
+    print(f"Aggregated text: {text_stream.aggregated_text}")

--- a/twelvelabs/base_client.py
+++ b/twelvelabs/base_client.py
@@ -37,9 +37,6 @@ class APIClient:
         except httpx.HTTPStatusError as e:
             raise self._make_status_error(e.response)
 
-        if "chunked" in response.headers.get("Transfer-Encoding", ""):
-            return response
-
         if len(response.content) > 0 and "application/json" in response.headers.get(
             "Content-Type", ""
         ):

--- a/twelvelabs/models/__init__.py
+++ b/twelvelabs/models/__init__.py
@@ -14,6 +14,7 @@ from .generate import (
     GenerateSummarizeHighlightResult,
     GenerateSummarizeResult,
     GenerateGistResult,
+    GenerateOpenEndedTextStreamResult,
 )
 from .classify import ClassifyClassParams, ClassifyPageResult
 from .embed import (
@@ -47,6 +48,7 @@ __all__ = [
     "GenerateSummarizeHighlightResult",
     "GenerateSummarizeResult",
     "GenerateGistResult",
+    "GenerateOpenEndedTextStreamResult",
     "CreateEmbeddingsResult",
     "EmbeddingsTask",
     "EmbeddingsTaskStatus",

--- a/twelvelabs/models/generate.py
+++ b/twelvelabs/models/generate.py
@@ -1,4 +1,7 @@
+import httpx
+import json
 from typing import List, Optional
+from pydantic import PrivateAttr
 
 from ._base import BaseModel, RootModelList
 
@@ -34,3 +37,52 @@ class GenerateGistResult(BaseModel):
     title: Optional[str] = None
     topics: Optional[RootModelList[str]] = None
     hashtags: Optional[RootModelList[str]] = None
+
+
+class GenerateOpenEndedTextStreamResult(BaseModel):
+    _stream: httpx.Response = PrivateAttr()
+    id: str = ""
+    texts: List[str] = []
+    aggregated_text: str = ""
+
+    def __init__(self, stream: httpx.Response, **data):
+        super().__init__(**data)
+        self._stream = stream
+        self.id = ""
+        self.texts = []
+        self.aggregated_text = ""
+
+    def add_text(self, text: str):
+        self.texts.append(text)
+        self.aggregated_text += text
+
+    def __iter__(self):
+        buffer = ""
+        with self._stream as response:
+            for line in response.iter_lines():
+                buffer += line
+                while True:
+                    try:
+                        event, index = json.JSONDecoder().raw_decode(buffer)
+                        buffer = buffer[index:].lstrip()
+                    except json.JSONDecodeError:
+                        break
+
+                    if "code" in event:
+                        # Handle non-stream error
+                        raise Exception(event["message"])
+                    elif event["event_type"] == "stream_start":
+                        self.id = event["metadata"]["generation_id"]
+                    elif event["event_type"] == "stream_error":
+                        raise Exception(event["error"]["message"])
+                    elif event["event_type"] == "text_generation":
+                        self.add_text(event["text"])
+                        yield event["text"]
+                    elif event["event_type"] == "stream_end":
+                        return
+
+            if buffer:
+                event = json.loads(buffer)
+                if event["event_type"] == "text_generation":
+                    self.add_text(event["text"])
+                    yield event["text"]

--- a/twelvelabs/models/generate.py
+++ b/twelvelabs/models/generate.py
@@ -63,7 +63,9 @@ class GenerateOpenEndedTextStreamResult(BaseModel):
                 buffer += line
                 while True:
                     try:
+                        # Try to decode a JSON object from the buffer
                         event, index = json.JSONDecoder().raw_decode(buffer)
+                        # Update the buffer to remove the decoded JSON object
                         buffer = buffer[index:].lstrip()
                     except json.JSONDecodeError:
                         break
@@ -82,6 +84,7 @@ class GenerateOpenEndedTextStreamResult(BaseModel):
                         return
 
             if buffer:
+                # If there's any remaining data in the buffer, process it
                 event = json.loads(buffer)
                 if event["event_type"] == "text_generation":
                     self.add_text(event["text"])

--- a/twelvelabs/resources/generate.py
+++ b/twelvelabs/resources/generate.py
@@ -52,3 +52,20 @@ class Generate(APIResource):
         }
         res = self._post("generate", json=json, **kwargs)
         return models.GenerateOpenEndedTextResult(**res)
+
+    def text_stream(
+        self,
+        video_id: str,
+        prompt: str,
+        *,
+        temperature: Optional[float] = None,
+        **kwargs,
+    ) -> models.GenerateOpenEndedTextStreamResult:
+        json = {
+            "video_id": video_id,
+            "prompt": prompt,
+            "temperature": temperature,
+            "stream": True,
+        }
+        res = self._post("generate", json=json, stream=True, **kwargs)
+        return models.GenerateOpenEndedTextStreamResult(stream=res)


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

This change handles streaming responses from API responses with Transfer-Encoding=chunked and supports them in open-ended text generation.

Returning two different types from a single method can lead to unnecessary tricky code, such as the use of type aliases. Therefore, I have separated this functionality into a distinct `text_stream` method.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).

## Further comments

Testing completed
<img width="673" alt="image" src="https://github.com/twelvelabs-io/twelvelabs-python/assets/155519863/b502f428-dc52-4ee8-97a5-a03997d667d8">
<img width="1341" alt="image" src="https://github.com/twelvelabs-io/twelvelabs-python/assets/155519863/6e861e41-a577-46f9-85d8-69cc1a19b2fe">
