### PR TITLE
feat: init method in client params

### DIFF
--- a/twelvelabs/models/classify.py
+++ b/twelvelabs/models/classify.py
@@ -17,6 +17,23 @@ class ClassifyClassParams:
     ] = None
     conversation_option: Optional[Union[str, Literal["semantic", "exact_match"]]] = None
 
+    def __init__(
+        self,
+        name: str,
+        prompts: List[str],
+        *,
+        options: Optional[
+            List[Union[str, Literal["visual", "conversation", "text_in_video"]]]
+        ] = None,
+        conversation_option: Optional[
+            Union[str, Literal["semantic", "exact_match"]]
+        ] = None,
+    ):
+        self.name = name
+        self.prompts = prompts
+        self.options = options
+        self.conversation_option = conversation_option
+
 
 class ClassifyDetailedScore(BaseModel):
     max_score: float

--- a/twelvelabs/models/embed.py
+++ b/twelvelabs/models/embed.py
@@ -17,6 +17,23 @@ class CreateEmbeddingsTaskVideoParams:
     clip_length: Optional[int]
     scopes: Optional[List[Literal["clip", "video"]]]
 
+    def __init__(
+        self,
+        file: Union[str, BinaryIO, None] = None,
+        *,
+        url: Optional[str] = None,
+        start_offset_sec: Optional[float] = None,
+        end_offset_sec: Optional[float] = None,
+        clip_length: Optional[int] = None,
+        scopes: Optional[List[Literal["clip", "video"]]] = None,
+    ):
+        self.file = file
+        self.url = url
+        self.start_offset_sec = start_offset_sec
+        self.end_offset_sec = end_offset_sec
+        self.clip_length = clip_length
+        self.scopes = scopes
+
 
 class Embedding(BaseModel):
     float: List[float]


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

Added `__init__` method in client params to enhance using exact fields when calling API methods

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
