### PR TITLE
fix: accessing response before init

### DIFF
--- a/twelvelabs/exceptions.py
+++ b/twelvelabs/exceptions.py
@@ -56,7 +56,7 @@ class APIConnectionError(APIError):
 
 
 class APITimeoutError(APIConnectionError):
-    def __init__(self, request: httpx.Request) -> None:
+    def __init__(self, *, request: httpx.Request) -> None:
         super().__init__(message="Request timed out", request=request)
 
 


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

Occasionally `cannot access local variable 'response' where it is not associated with a value` occurred since request method is accessing `response` before initialized. Fixed to safely access `response` variable.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).