### PR TITLE
Send URLs as files. Workaround for #50

### DIFF
--- a/twelvelabs/resources/task.py
+++ b/twelvelabs/resources/task.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from typing import Optional, Union, BinaryIO, List, Dict
 
 from ..models import RootModelList
@@ -126,9 +127,6 @@ class Task(APIResource):
                 file = open(file, "rb")
                 opened_files.append(file)
             files["video_file"] = file
-        else:
-            # Request should be sent as multipart-form even file not exists
-            files["dummy"] = ("", "")
 
         if transcription_file is not None:
             if isinstance(transcription_file, str):
@@ -138,6 +136,11 @@ class Task(APIResource):
             data["provide_transcription"] = True
         if transcription_url is not None:
             data["provide_transcription"] = True
+
+        if url is not None:
+            files['video_url'] = BytesIO(url.encode())
+        if transcription_url is not None:
+            files['transcription_url'] = BytesIO(transcription_url.encode())
 
         try:
             res = self._post(


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

Currently you receive an error if you try to index a URL rather than a video file (see issue #50). This change works around the problem by sending URLs as file data. There should probably be a fix in the relevant endpoints in the service to not assume that parameters are always being sent as files.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).

## Further comments

<!-- If there's anything else you'd like to add about the pull request, put it here. -->
