### PR TITLE
fix: field validation on `VideoEmbedding`

### DIFF
--- a/examples/embed.py
+++ b/examples/embed.py
@@ -37,4 +37,4 @@ with TwelveLabs(API_KEY) as client:
             print(
                 f"embedding_scope={v.embedding_scope} start_offset_sec={v.start_offset_sec} end_offset_sec={v.end_offset_sec}"
             )
-            print(f"embeddings: {", ".join(str(v.embedding.float))}")
+            print(f"embeddings: {", ".join(str(v.values))}")

--- a/twelvelabs/models/embed.py
+++ b/twelvelabs/models/embed.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import List, Union, BinaryIO, Optional, Literal, Callable, TYPE_CHECKING
-from pydantic import PrivateAttr
+from pydantic import PrivateAttr, Field
 
 from ._base import BaseModel, Object, RootModelList
 
@@ -53,7 +53,7 @@ class VideoEmbedding(BaseModel):
     start_offset_sec: float
     end_offset_sec: float
     embedding_scope: str
-    embedding: Embedding
+    values: Optional[List[float]] = Field(default=None, alias="float")
 
 
 class EmbeddingsTask(Object):


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

`embedding` field changed to `float`, so pydantic validation was failed.
we can't use "float" named key of optional field, so used with alias `values`, it's same approach with [embedding changes PR](https://github.com/twelvelabs-io/twelvelabs-python/pull/91)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
