### PR TITLE
fix: generate non-stream

### DIFF
--- a/twelvelabs/resources/generate.py
+++ b/twelvelabs/resources/generate.py
@@ -36,6 +36,7 @@ class Generate(APIResource):
             "video_id": video_id,
             "prompt": prompt,
             "temperature": temperature,
+            "stream": False,
         }
         res = self._post("generate", json=json, **kwargs)
         return models.GenerateOpenEndedTextResult(**res)


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

Since we've already separated /generate endpoint with `textStream` and `text`, so we should add `stream: false` to `text` method params.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).