### PR TITLE
fix: GenerateSummarizeHighlightResult number type

### DIFF
--- a/twelvelabs/models/generate.py
+++ b/twelvelabs/models/generate.py
@@ -20,8 +20,8 @@ class GenerateSummarizeChapterResult(BaseModel):
 
 
 class GenerateSummarizeHighlightResult(BaseModel):
-    start: int
-    end: int
+    start: float
+    end: float
     highlight: str
 
 


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

start and end of GenerateSummarizeHighlightResult should be float, not int. this causes pydantic validation error.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
