### PR TITLE
feat: support multi-vector for embedding retrieval api

### DIFF
--- a/examples/embed.py
+++ b/examples/embed.py
@@ -73,6 +73,8 @@ with TwelveLabs(API_KEY) as client:
     status = task.wait_for_done(callback=on_task_update)
     print(f"Embedding done: {status}")
 
-    task = task.retrieve()
+    # Retrieve the task with the specified embedding option: "visual-text". 
+    # If you don't specify the embedding option, it will return all available multi-vector embeddings.
+    task = task.retrieve(embedding_option=["visual-text"])
     if task.video_embedding is not None and task.video_embedding.segments is not None:
         print_segments(task.video_embedding.segments)

--- a/examples/embed.py
+++ b/examples/embed.py
@@ -16,9 +16,10 @@ with TwelveLabs(API_KEY) as client:
     def print_segments(segments: List[SegmentEmbedding]):
         for segment in segments:
             print(
-                f"  embedding_scope={segment.embedding_scope} start_offset_sec={segment.start_offset_sec} end_offset_sec={segment.end_offset_sec}"
+                f"  embedding_scope={segment.embedding_scope} embedding_option={segment.embedding_option} start_offset_sec={segment.start_offset_sec} end_offset_sec={segment.end_offset_sec}"
             )
-            print(f"  embeddings: {", ".join(str(segment.embeddings_float))}")
+            first_few = segment.embeddings_float[:5]  # Show just first 5 values
+            print(f"  embeddings: [{', '.join(str(x) for x in first_few)}...] (total: {len(segment.embeddings_float)} values)")
 
     embed_tasks = client.embed.task.list()
     for task in embed_tasks:

--- a/examples/video.py
+++ b/examples/video.py
@@ -46,3 +46,15 @@ with TwelveLabs(API_KEY) as client:
     )
     video = client.index.video.retrieve(index.id, videos[0].id)
     print(f"Updated first video: id={video.id} metadata={video.user_metadata}")
+
+    # Get the first video and print its embeddings
+    video = client.index.video.retrieve(index.id, videos[0].id, embedding_option=["visual-text", "audio"])
+
+    if hasattr(video, 'embedding') and video.embedding and video.embedding.video_embedding:
+        print("\nVideo Embeddings:")
+        for i, segment in enumerate(video.embedding.video_embedding.segments):
+            print(
+                f"  embedding_scope={segment.embedding_scope} embedding_option={segment.embedding_option} start_offset_sec={segment.start_offset_sec} end_offset_sec={segment.end_offset_sec}"
+            )
+            first_few = segment.embeddings_float[:5]  # Show just first 5 values
+            print(f"  embeddings: [{', '.join(str(x) for x in first_few)}...] (total: {len(segment.embeddings_float)} values)")

--- a/twelvelabs/models/embed.py
+++ b/twelvelabs/models/embed.py
@@ -59,6 +59,7 @@ class SegmentEmbedding(BaseModel):
     start_offset_sec: Optional[float] = None
     end_offset_sec: Optional[float] = None
     embedding_scope: Optional[str] = None
+    embedding_option: Optional[str] = None
     embeddings_float: Optional[List[float]] = Field(default=None, alias="float")
 
 

--- a/twelvelabs/resources/embed.py
+++ b/twelvelabs/resources/embed.py
@@ -13,12 +13,12 @@ if TYPE_CHECKING:
 
 
 class EmbedTask(APIResource):
-    def retrieve(self, id: str, embedding_option: Optional[List[str]] = None, **kwargs) -> models.EmbeddingsTask:
-        params = {}
-        if embedding_option:
-            params["embedding_option"] = embedding_option
+    def retrieve(self, id: str, *, embedding_option: Optional[List[str]] = None, **kwargs) -> models.EmbeddingsTask:
+        params = {
+            "embedding_option": embedding_option
+        }
         
-        res = self._get(f"embed/tasks/{id}", params=params, **kwargs)
+        res = self._get(f"embed/tasks/{id}", params=remove_none_values(params), **kwargs)
         return models.EmbeddingsTask(self, **res)
 
     def list(

--- a/twelvelabs/resources/embed.py
+++ b/twelvelabs/resources/embed.py
@@ -13,8 +13,12 @@ if TYPE_CHECKING:
 
 
 class EmbedTask(APIResource):
-    def retrieve(self, id: str, **kwargs) -> models.EmbeddingsTask:
-        res = self._get(f"embed/tasks/{id}", **kwargs)
+    def retrieve(self, id: str, embedding_option: Optional[List[str]] = None, **kwargs) -> models.EmbeddingsTask:
+        params = {}
+        if embedding_option:
+            params["embedding_option"] = embedding_option
+        
+        res = self._get(f"embed/tasks/{id}", params=params, **kwargs)
         return models.EmbeddingsTask(self, **res)
 
     def list(

--- a/twelvelabs/resources/video.py
+++ b/twelvelabs/resources/video.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any, Union, List
 
 from ..models._base import RootModelList
 from ..resource import APIResource
@@ -16,11 +16,11 @@ class Video(APIResource):
         index_id: str,
         id: str,
         *,
-        embed: Optional[bool] = None,
+        embedding_option: Optional[List[str]] = None,
         **kwargs,
     ) -> models.Video:
         params = {
-            "embed": embed,
+            "embedding_option": embedding_option,
         }
         res = self._get(
             f"indexes/{index_id}/videos/{id}",


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

<!-- Please provide a detailed description of the pull request, including the purpose of the change, the problem it solves, or the feature it adds to the project. Ensure you link any relevant issues this PR addresses. -->

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [ x I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [] I have added necessary documentation (if appropriate).

## Further comments
Support multi-vector retrieval for video. 

**`embedding_option`** Specifies which types of embeddings to retrieve. You can include one or more of the following values:
  - `visual-text`:  Returns visual embeddings optimized for text search.
  - `audio`: Returns audio embeddings.
To retrieve embeddings for a video, it must be indexed using the Marengo video understanding model version 2.7 or later. For details on enabling this model for an index, see the [Create an index](/reference/create-index) page. 
        
The platform does not return embeddings if you don't provide this parameter.
        
The values you specify in `embedding_option` must be included in the `model_options` defined when the index was created. For example, if `model_options` is set to `visual,` you cannot set `embedding_option` to `audio` or  both `visual-text` and `audio`.

## Testing done
```
python examples/video.py
...
Video Embeddings:
  embedding_scope=clip embedding_option=visual-text start_offset_sec=0.0 end_offset_sec=5.633333
  embeddings: [0.022289429, 0.023040682, -0.0070309793, 0.030225465, -0.019720418...] (total: 1024 values)
  embedding_scope=clip embedding_option=visual-text start_offset_sec=5.6666665 end_offset_sec=11.0
  embeddings: [0.0153732365, 0.008101929, 0.019717632, 0.0011863402, -0.016370542...] (total: 1024 values)
  embedding_scope=clip embedding_option=visual-text start_offset_sec=11.033333 end_offset_sec=17.0
  embeddings: [0.019108446, 0.012770501, 0.005272033, 0.02110252, 0.009162065...] (total: 1024 values)
  embedding_scope=clip embedding_option=visual-text start_offset_sec=17.033333 end_offset_sec=23.966667
  embeddings: [0.03796209, 0.016766332, 0.0068343384, 0.036316212, -0.0005206473...] (total: 1024 values)
  embedding_scope=clip embedding_option=visual-text start_offset_sec=24.0 end_offset_sec=30.03
  embeddings: [0.04650928, 0.019342415, 0.040071126, 0.043216992, 0.0027235553...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=0.0 end_offset_sec=5.633333
  embeddings: [-0.03515625, -0.02331543, -0.016967773, -0.020019531, -0.012756348...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=5.6666665 end_offset_sec=11.0
  embeddings: [-0.032714844, -0.026123047, -0.022705078, -0.040771484, -0.012084961...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=11.033333 end_offset_sec=17.0
  embeddings: [-0.051757812, -0.008544922, -0.019165039, -0.0030212402, -0.022460938...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=17.033333 end_offset_sec=23.966667
  embeddings: [-0.049804688, -0.02355957, -0.02722168, -0.025512695, -0.025390625...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=24.0 end_offset_sec=30.03
  embeddings: [-0.026611328, -0.013244629, -0.004333496, -0.03930664, -0.022949219...] (total: 1024 values)
```
```
python examples/embed.py
Embedding task: id=67f9f09329cf7e91dd6f380d status=ready created_at=2025-04-12T04:48:20.12Z
Embedding task: id=67f9efbac50a101c7a091e92 status=ready created_at=2025-04-12T04:44:43.222Z
Embedding task: id=67f9eb2f29cf7e91dd6f3809 status=ready created_at=2025-04-12T04:25:20.198Z
Embedding task: id=67f4a17dc5bae8638a63849e status=ready created_at=2025-04-08T04:09:33.933Z
Created text embedding: model_name=Marengo-retrieval-2.7
  embedding_scope=None embedding_option=None start_offset_sec=None end_offset_sec=None
  embeddings: [0.009277344, -0.017089844, 0.0021820068, -0.040527344, 0.03515625...] (total: 1024 values)
Created image embedding: model_name=Marengo-retrieval-2.7
  embedding_scope=None embedding_option=None start_offset_sec=None end_offset_sec=None
  embeddings: [0.04443546, -0.04158418, 0.0015328148, 0.023962587, -0.008246706...] (total: 1024 values)
Created audio embedding: model_name=Marengo-retrieval-2.7
  embedding_scope=None embedding_option=None start_offset_sec=0.0 end_offset_sec=None
  embeddings: [-0.071777344, -0.030151367, -0.0013961792, -0.045898438, -0.020996094...] (total: 1024 values)
Created task: id=67f9f22bc50a101c7a091e96 model_name=Marengo-retrieval-2.7 status=processing
  Status=processing
  Status=processing
  Status=processing
  Status=processing
  Status=processing
  Status=processing
  Status=processing
  Status=processing
  Status=processing
  Status=ready
Embedding done: ready
  embedding_scope=clip embedding_option=visual-text start_offset_sec=0.0 end_offset_sec=6.0
  embeddings: [0.013130074, -0.010898346, -0.0077810767, -0.016174367, -0.038313843...] (total: 1024 values)
...
  embeddings: [-0.026000977, -0.03466797, -0.025024414, -0.056884766, -0.025390625...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=138.0 end_offset_sec=144.0
  embeddings: [-0.03173828, -0.060302734, -0.005004883, 0.0041503906, -0.03564453...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=144.0 end_offset_sec=150.0
  embeddings: [-0.013366699, -0.04711914, -0.010437012, 0.01940918, -0.03515625...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=150.0 end_offset_sec=156.0
  embeddings: [-0.0115356445, -0.008483887, -0.0010604858, 0.020751953, -0.04663086...] (total: 1024 values)
  embedding_scope=clip embedding_option=audio start_offset_sec=156.0 end_offset_sec=160.44
  embeddings: [-0.025146484, -0.046875, -0.013671875, -0.00390625, -0.048583984...] (total: 1024 values)  
```