### PR TITLE
fix: assert syntax warning

### DIFF
--- a/twelvelabs/client.py
+++ b/twelvelabs/client.py
@@ -31,9 +31,8 @@ class TwelveLabs(APIClient):
                 f"[Warning] You manually set the API version to {version}, but this SDK version is not fully compatible with current API version, please use version 0.3.x or earlier"
             )
         assert (
-            api_key,
-            "Provide `api_key` to initialize a client. You can see the API Key in the Dashboard page: https://dashboard.playground.io",
-        )
+            api_key
+        ), "Provide `api_key` to initialize a client. You can see the API Key in the Dashboard page: https://dashboard.playground.io"
         base_url = f"{BASE_URL}/{version}/"
         custom_base_url = os.environ.get("TWELVELABS_BASE_URL")
         if custom_base_url is not None:


### PR DESCRIPTION
<!-- Thank you for helping to improve our project!
Please provide a description and review the requirements.

Contributors guide: https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTING.md -->

## Description

<!-- Please provide a detailed description of the pull request, including the purpose of the change, the problem it solves, or the feature it adds to the project. Ensure you link any relevant issues this PR addresses. -->

over python 3.12, current assert shows syntax warning since it handles first params as a tuple.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Others

## Checklist

Before you submit this PR, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/CONTRIBUTE.md) document.
- [x] I have ensured my PR title is descriptive and in imperative mood.
- [x] I have added necessary documentation (if appropriate).
