### PR TITLE
fix: fire wait_for_done callback for already-terminal tasks

### DIFF
--- a/src/twelvelabs/wrapper/embed_client_wrapper.py
+++ b/src/twelvelabs/wrapper/embed_client_wrapper.py
@@ -188,11 +188,14 @@ class EmbedTasksClientWrapper(TasksClient):
         if sleep_interval <= 0:
             raise ValueError("sleep_interval must be greater than 0")
 
-        # Get initial task
-        task = self.status(task_id, request_options=request_options)
-
-        # Check if it's already done
         done_statuses = ["ready", "failed"]
+
+        # Get the initial task and report its status immediately. This covers the
+        # case where the task is already terminal at entry (the callback would
+        # otherwise never fire because the polling loop below would not execute).
+        task = self.status(task_id, request_options=request_options)
+        if callback is not None:
+            callback(task)
 
         while task.status not in done_statuses:
             time.sleep(sleep_interval)
@@ -377,11 +380,14 @@ class AsyncEmbedTasksClientWrapper(AsyncTasksClient):
         if sleep_interval <= 0:
             raise ValueError("sleep_interval must be greater than 0")
 
-        # Get initial task
-        task = await self.status(task_id, request_options=request_options)
-
-        # Check if it's already done
         done_statuses = ["ready", "failed"]
+
+        # Get the initial task and report its status immediately. This covers the
+        # case where the task is already terminal at entry (the callback would
+        # otherwise never fire because the polling loop below would not execute).
+        task = await self.status(task_id, request_options=request_options)
+        if callback is not None:
+            await callback(task)
 
         while task.status not in done_statuses:
             await asyncio.sleep(sleep_interval)

--- a/src/twelvelabs/wrapper/task_client_wrapper.py
+++ b/src/twelvelabs/wrapper/task_client_wrapper.py
@@ -158,11 +158,14 @@ class TaskClientWrapper(TasksClient):
         if sleep_interval <= 0:
             raise ValueError("sleep_interval must be greater than 0")
 
-        # Get initial task
-        task = self.retrieve(task_id, request_options=request_options)
-
-        # Check if it's already done
         done_statuses = ["ready", "failed"]
+
+        # Get the initial task and report its status immediately. This covers the
+        # case where the task is already terminal at entry (the callback would
+        # otherwise never fire because the polling loop below would not execute).
+        task = self.retrieve(task_id, request_options=request_options)
+        if callback is not None:
+            callback(task)
 
         # Continue checking until it's done
         while task.status not in done_statuses:
@@ -343,11 +346,14 @@ class AsyncTaskClientWrapper(AsyncTasksClient):
         if sleep_interval <= 0:
             raise ValueError("sleep_interval must be greater than 0")
 
-        # Get initial task
-        task = await self.retrieve(task_id, request_options=request_options)
-
-        # Check if it's already done
         done_statuses = ["ready", "failed"]
+
+        # Get the initial task and report its status immediately. This covers the
+        # case where the task is already terminal at entry (the callback would
+        # otherwise never fire because the polling loop below would not execute).
+        task = await self.retrieve(task_id, request_options=request_options)
+        if callback is not None:
+            await callback(task)
 
         # Continue checking until it's done
         while task.status not in done_statuses:

--- a/tests/custom/test_wait_for_done.py
+++ b/tests/custom/test_wait_for_done.py
@@ -1,0 +1,412 @@
+"""Tests for ``wait_for_done`` callback behavior (QA-3371).
+
+Regression coverage for the bug where the caller-supplied ``callback`` was only
+invoked from inside the polling ``while`` loop. As a result, a task that was
+*already terminal* (``ready``/``failed``) at the moment ``wait_for_done`` was
+called never fired the callback, and the very first observed status of an
+in-progress task was also skipped.
+
+The fix invokes ``callback`` once immediately after the initial fetch, then on
+every subsequent poll through the terminal status.
+
+These tests exercise all four implementations:
+
+* ``TaskClientWrapper.wait_for_done`` (sync, uses ``retrieve``)
+* ``AsyncTaskClientWrapper.wait_for_done`` (async, uses ``retrieve``)
+* ``EmbedTasksClientWrapper.wait_for_done`` (sync, uses ``status``)
+* ``AsyncEmbedTasksClientWrapper.wait_for_done`` (async, uses ``status``)
+"""
+
+import typing
+from unittest import mock
+
+from twelvelabs.embed.tasks.types.tasks_status_response import TasksStatusResponse
+from twelvelabs.tasks.types.tasks_retrieve_response import TasksRetrieveResponse
+from twelvelabs.wrapper.embed_client_wrapper import (
+    AsyncEmbedTasksClientWrapper,
+    EmbedTasksClientWrapper,
+)
+from twelvelabs.wrapper.task_client_wrapper import (
+    AsyncTaskClientWrapper,
+    TaskClientWrapper,
+)
+
+TASK_MODULE = "twelvelabs.wrapper.task_client_wrapper"
+EMBED_MODULE = "twelvelabs.wrapper.embed_client_wrapper"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _task_responses(statuses: typing.List[str]) -> typing.List[TasksRetrieveResponse]:
+    return [TasksRetrieveResponse(status=status) for status in statuses]
+
+
+def _embed_responses(statuses: typing.List[str]) -> typing.List[TasksStatusResponse]:
+    return [TasksStatusResponse(status=status) for status in statuses]
+
+
+def _make_sync_task_wrapper(
+    statuses: typing.List[str],
+) -> typing.Tuple[TaskClientWrapper, mock.Mock]:
+    # Bypass __init__ (which needs a real client wrapper) and stub the fetch.
+    wrapper = TaskClientWrapper.__new__(TaskClientWrapper)
+    fetch = mock.Mock(side_effect=_task_responses(statuses))
+    setattr(wrapper, "retrieve", fetch)
+    return wrapper, fetch
+
+
+def _make_async_task_wrapper(
+    statuses: typing.List[str],
+) -> typing.Tuple[AsyncTaskClientWrapper, mock.AsyncMock]:
+    wrapper = AsyncTaskClientWrapper.__new__(AsyncTaskClientWrapper)
+    fetch = mock.AsyncMock(side_effect=_task_responses(statuses))
+    setattr(wrapper, "retrieve", fetch)
+    return wrapper, fetch
+
+
+def _make_sync_embed_wrapper(
+    statuses: typing.List[str],
+) -> typing.Tuple[EmbedTasksClientWrapper, mock.Mock]:
+    wrapper = EmbedTasksClientWrapper.__new__(EmbedTasksClientWrapper)
+    fetch = mock.Mock(side_effect=_embed_responses(statuses))
+    setattr(wrapper, "status", fetch)
+    return wrapper, fetch
+
+
+def _make_async_embed_wrapper(
+    statuses: typing.List[str],
+) -> typing.Tuple[AsyncEmbedTasksClientWrapper, mock.AsyncMock]:
+    wrapper = AsyncEmbedTasksClientWrapper.__new__(AsyncEmbedTasksClientWrapper)
+    fetch = mock.AsyncMock(side_effect=_embed_responses(statuses))
+    setattr(wrapper, "status", fetch)
+    return wrapper, fetch
+
+
+# --------------------------------------------------------------------------- #
+# sync TaskClientWrapper.wait_for_done
+# --------------------------------------------------------------------------- #
+def test_sync_task_already_ready_fires_callback_once() -> None:
+    wrapper, fetch = _make_sync_task_wrapper(["ready"])
+    callback = mock.Mock()
+
+    with mock.patch(f"{TASK_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(task_id="t", callback=callback)
+
+    assert result.status == "ready"
+    callback.assert_called_once_with(result)
+    sleep_mock.assert_not_called()
+    assert fetch.call_count == 1
+
+
+def test_sync_task_already_failed_fires_callback_once() -> None:
+    wrapper, fetch = _make_sync_task_wrapper(["failed"])
+    callback = mock.Mock()
+
+    with mock.patch(f"{TASK_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(task_id="t", callback=callback)
+
+    assert result.status == "failed"
+    callback.assert_called_once_with(result)
+    sleep_mock.assert_not_called()
+    assert fetch.call_count == 1
+
+
+def test_sync_task_progress_sequence_fires_each_status() -> None:
+    wrapper, fetch = _make_sync_task_wrapper(["pending", "indexing", "ready"])
+    observed: typing.List[str] = []
+    callback = mock.Mock(side_effect=lambda task: observed.append(task.status))
+
+    with mock.patch(f"{TASK_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(
+            task_id="t", sleep_interval=1.0, callback=callback
+        )
+
+    assert observed == ["pending", "indexing", "ready"]
+    assert result.status == "ready"
+    assert sleep_mock.call_count == 2
+    assert fetch.call_count == 3
+
+
+def test_sync_task_callback_none_already_ready() -> None:
+    wrapper, fetch = _make_sync_task_wrapper(["ready"])
+
+    with mock.patch(f"{TASK_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(task_id="t", callback=None)
+
+    assert result.status == "ready"
+    sleep_mock.assert_not_called()
+    assert fetch.call_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# async AsyncTaskClientWrapper.wait_for_done
+# --------------------------------------------------------------------------- #
+async def test_async_task_already_ready_fires_callback_once() -> None:
+    wrapper, fetch = _make_async_task_wrapper(["ready"])
+    callback = mock.AsyncMock()
+
+    with mock.patch(
+        f"{TASK_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(task_id="t", callback=callback)
+
+    assert result.status == "ready"
+    callback.assert_awaited_once_with(result)
+    sleep_mock.assert_not_awaited()
+    assert fetch.await_count == 1
+
+
+async def test_async_task_already_failed_fires_callback_once() -> None:
+    wrapper, fetch = _make_async_task_wrapper(["failed"])
+    callback = mock.AsyncMock()
+
+    with mock.patch(
+        f"{TASK_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(task_id="t", callback=callback)
+
+    assert result.status == "failed"
+    callback.assert_awaited_once_with(result)
+    sleep_mock.assert_not_awaited()
+    assert fetch.await_count == 1
+
+
+async def test_async_task_progress_sequence_fires_each_status() -> None:
+    wrapper, fetch = _make_async_task_wrapper(["pending", "indexing", "ready"])
+    observed: typing.List[str] = []
+
+    async def callback(task: TasksRetrieveResponse) -> None:
+        observed.append(typing.cast(str, task.status))
+
+    with mock.patch(
+        f"{TASK_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(
+            task_id="t", sleep_interval=1.0, callback=callback
+        )
+
+    assert observed == ["pending", "indexing", "ready"]
+    assert result.status == "ready"
+    assert sleep_mock.await_count == 2
+    assert fetch.await_count == 3
+
+
+async def test_async_task_callback_none_already_ready() -> None:
+    wrapper, fetch = _make_async_task_wrapper(["ready"])
+
+    with mock.patch(
+        f"{TASK_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(task_id="t", callback=None)
+
+    assert result.status == "ready"
+    sleep_mock.assert_not_awaited()
+    assert fetch.await_count == 1
+
+
+async def test_async_task_async_callback_is_awaited() -> None:
+    wrapper, _ = _make_async_task_wrapper(["ready"])
+    callback = mock.AsyncMock()
+
+    with mock.patch(f"{TASK_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock):
+        result = await wrapper.wait_for_done(task_id="t", callback=callback)
+
+    # An async callback must be awaited, not merely called.
+    callback.assert_awaited_once_with(result)
+
+
+# --------------------------------------------------------------------------- #
+# sync EmbedTasksClientWrapper.wait_for_done
+# --------------------------------------------------------------------------- #
+def test_sync_embed_already_ready_fires_callback_once() -> None:
+    wrapper, fetch = _make_sync_embed_wrapper(["ready"])
+    callback = mock.Mock()
+
+    with mock.patch(f"{EMBED_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(task_id="t", callback=callback)
+
+    assert result.status == "ready"
+    callback.assert_called_once_with(result)
+    sleep_mock.assert_not_called()
+    assert fetch.call_count == 1
+
+
+def test_sync_embed_already_failed_fires_callback_once() -> None:
+    wrapper, fetch = _make_sync_embed_wrapper(["failed"])
+    callback = mock.Mock()
+
+    with mock.patch(f"{EMBED_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(task_id="t", callback=callback)
+
+    assert result.status == "failed"
+    callback.assert_called_once_with(result)
+    sleep_mock.assert_not_called()
+    assert fetch.call_count == 1
+
+
+def test_sync_embed_progress_sequence_fires_each_status() -> None:
+    wrapper, fetch = _make_sync_embed_wrapper(["processing", "processing", "ready"])
+    observed: typing.List[str] = []
+    callback = mock.Mock(side_effect=lambda task: observed.append(task.status))
+
+    with mock.patch(f"{EMBED_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(
+            task_id="t", sleep_interval=1.0, callback=callback
+        )
+
+    assert observed == ["processing", "processing", "ready"]
+    assert result.status == "ready"
+    assert sleep_mock.call_count == 2
+    assert fetch.call_count == 3
+
+
+def test_sync_embed_callback_none_already_ready() -> None:
+    wrapper, fetch = _make_sync_embed_wrapper(["ready"])
+
+    with mock.patch(f"{EMBED_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(task_id="t", callback=None)
+
+    assert result.status == "ready"
+    sleep_mock.assert_not_called()
+    assert fetch.call_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# async AsyncEmbedTasksClientWrapper.wait_for_done
+# --------------------------------------------------------------------------- #
+async def test_async_embed_already_ready_fires_callback_once() -> None:
+    wrapper, fetch = _make_async_embed_wrapper(["ready"])
+    callback = mock.AsyncMock()
+
+    with mock.patch(
+        f"{EMBED_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(task_id="t", callback=callback)
+
+    assert result.status == "ready"
+    callback.assert_awaited_once_with(result)
+    sleep_mock.assert_not_awaited()
+    assert fetch.await_count == 1
+
+
+async def test_async_embed_already_failed_fires_callback_once() -> None:
+    wrapper, fetch = _make_async_embed_wrapper(["failed"])
+    callback = mock.AsyncMock()
+
+    with mock.patch(
+        f"{EMBED_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(task_id="t", callback=callback)
+
+    assert result.status == "failed"
+    callback.assert_awaited_once_with(result)
+    sleep_mock.assert_not_awaited()
+    assert fetch.await_count == 1
+
+
+async def test_async_embed_progress_sequence_fires_each_status() -> None:
+    wrapper, fetch = _make_async_embed_wrapper(["processing", "processing", "ready"])
+    observed: typing.List[str] = []
+
+    async def callback(task: TasksStatusResponse) -> None:
+        observed.append(typing.cast(str, task.status))
+
+    with mock.patch(
+        f"{EMBED_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(
+            task_id="t", sleep_interval=1.0, callback=callback
+        )
+
+    assert observed == ["processing", "processing", "ready"]
+    assert result.status == "ready"
+    assert sleep_mock.await_count == 2
+    assert fetch.await_count == 3
+
+
+async def test_async_embed_callback_none_already_ready() -> None:
+    wrapper, fetch = _make_async_embed_wrapper(["ready"])
+
+    with mock.patch(
+        f"{EMBED_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(task_id="t", callback=None)
+
+    assert result.status == "ready"
+    sleep_mock.assert_not_awaited()
+    assert fetch.await_count == 1
+
+
+async def test_async_embed_async_callback_is_awaited() -> None:
+    wrapper, _ = _make_async_embed_wrapper(["ready"])
+    callback = mock.AsyncMock()
+
+    with mock.patch(f"{EMBED_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock):
+        result = await wrapper.wait_for_done(task_id="t", callback=callback)
+
+    # An async callback must be awaited, not merely called.
+    callback.assert_awaited_once_with(result)
+
+
+# --------------------------------------------------------------------------- #
+# Retry path: a failed re-fetch is retried (`continue`) WITHOUT firing the
+# callback. This branch lives inside the polling loop that the fix reorganizes,
+# so it is exercised for both the sync/`time` path (task wrapper) and the
+# async/`asyncio` path (embed wrapper); the other two methods are structurally
+# identical. These also pin the fetch call arguments.
+# --------------------------------------------------------------------------- #
+def test_sync_task_retry_on_fetch_error_does_not_fire_callback() -> None:
+    wrapper = TaskClientWrapper.__new__(TaskClientWrapper)
+    fetch = mock.Mock(
+        side_effect=[
+            TasksRetrieveResponse(status="pending"),
+            RuntimeError("transient"),
+            TasksRetrieveResponse(status="ready"),
+        ]
+    )
+    setattr(wrapper, "retrieve", fetch)
+    observed: typing.List[str] = []
+    callback = mock.Mock(side_effect=lambda task: observed.append(task.status))
+
+    with mock.patch(f"{TASK_MODULE}.time.sleep") as sleep_mock:
+        result = wrapper.wait_for_done(
+            task_id="t", sleep_interval=1.0, callback=callback
+        )
+
+    # Callback fires for the initial `pending` and terminal `ready`, but NOT for
+    # the iteration whose re-fetch raised (that iteration hits `continue`).
+    assert observed == ["pending", "ready"]
+    assert result.status == "ready"
+    assert fetch.call_count == 3
+    assert sleep_mock.call_count == 2
+    fetch.assert_called_with("t", request_options=None)
+
+
+async def test_async_embed_retry_on_fetch_error_does_not_fire_callback() -> None:
+    wrapper = AsyncEmbedTasksClientWrapper.__new__(AsyncEmbedTasksClientWrapper)
+    fetch = mock.AsyncMock(
+        side_effect=[
+            TasksStatusResponse(status="processing"),
+            RuntimeError("transient"),
+            TasksStatusResponse(status="ready"),
+        ]
+    )
+    setattr(wrapper, "status", fetch)
+    observed: typing.List[str] = []
+
+    async def callback(task: TasksStatusResponse) -> None:
+        observed.append(typing.cast(str, task.status))
+
+    with mock.patch(
+        f"{EMBED_MODULE}.asyncio.sleep", new_callable=mock.AsyncMock
+    ) as sleep_mock:
+        result = await wrapper.wait_for_done(
+            task_id="t", sleep_interval=1.0, callback=callback
+        )
+
+    assert observed == ["processing", "ready"]
+    assert result.status == "ready"
+    assert fetch.await_count == 3
+    assert sleep_mock.await_count == 2
+    fetch.assert_awaited_with("t", request_options=None)


### PR DESCRIPTION
## Summary

Fixes `wait_for_done` did not fire the caller-supplied `callback` when the task was already in a terminal state (`ready`/`failed`) at the moment the method was called.

`wait_for_done` invoked `callback` **only from inside** the polling `while task.status not in done_statuses:` loop, so:

- A task already terminal at entry skipped the loop body entirely → the callback **never fired**.
- Even for an in-progress task, the **initial** observed status was never delivered (the callback only started firing after the first `sleep` + re-fetch).

## Fix

Invoke `callback` **once immediately after the initial fetch** (before the loop), keeping the existing in-loop invocation. Applied identically to all four implementations:

| File | Method |
|------|--------|
| `wrapper/task_client_wrapper.py` | `TaskClientWrapper.wait_for_done` (sync) |
| `wrapper/task_client_wrapper.py` | `AsyncTaskClientWrapper.wait_for_done` (async — awaits fetch + callback) |
| `wrapper/embed_client_wrapper.py` | `EmbedTasksClientWrapper.wait_for_done` (sync) |
| `wrapper/embed_client_wrapper.py` | `AsyncEmbedTasksClientWrapper.wait_for_done` (async — awaits fetch + callback) |

Result:
- An already-`ready`/`failed` task fires the callback **exactly once** (the fix).
- An in-progress task reports its **initial** status immediately, then on **every** poll through the terminal status.

> [!NOTE]
> These wrappers are **hand-written and protected by `.fernignore`** (`src/twelvelabs/wrapper/`) — they are **not** regenerated by Fern, so the fix lives here and will not be overwritten on the next generated release. (The repo's standard "generated code" PR notice does not apply to these files.)

## Out of scope (unchanged)

No change to public signatures, the default `sleep_interval`, the `sleep_interval <= 0` validation, the retry-on-exception `print(...)`/`continue` behavior, `done_statuses`, or the return value (still returns the terminal task). **No version bump** — left to the release process.

## Tests

New `tests/custom/test_wait_for_done.py` — 20 tests across all 4 methods:

1. Already `ready` at entry → callback fires **exactly once**, `sleep` **not** called.
2. Already `failed` at entry → callback fires once.
3. Progress sequence (`pending`→`indexing`→`ready` for tasks, `processing`→`ready` for embed) → callback fires for **each** observed status in order; returns the terminal task.
4. `callback=None` on an already-ready task → no error, returns the task.
5. (async) the async callback is **awaited**, not merely called.
6. Retry path: a failed re-fetch is retried (`continue`) **without** firing the callback — covers the loop branch the fix reorganizes.

The callback-firing assertions were verified to **fail against the original buggy code** and pass against the fix.

## Verification

- `poetry run pytest -rP . --ignore=legacy --ignore=0.4` → **32 passed, 1 skipped**
- `poetry run mypy . --exclude legacy --exclude 0.4` → **Success: no issues found in 376 source files**
- `ruff` clean on the new test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
