### PR TITLE
docs: add knowledge stores + responses (Agents API) examples

### DIFF
--- a/examples/_ks_helpers.py
+++ b/examples/_ks_helpers.py
@@ -8,7 +8,7 @@ reuse them in your own scripts.
 Environment:
     API_KEY               (required) your TwelveLabs API key
     TWELVELABS_BASE_URL   (optional) override the API base URL. When unset the
-                          SDK default (prod, https://api.twelvelabs.io/v1.3) is used.
+                          SDK default (https://api.twelvelabs.io/v1.3) is used.
 """
 
 import os

--- a/examples/_ks_helpers.py
+++ b/examples/_ks_helpers.py
@@ -1,0 +1,157 @@
+"""Shared helpers for the knowledge-store and responses examples.
+
+These utilities create assets, spin up a knowledge store, add items, and poll
+until everything is ready so the search / responses examples have real content
+to run against. Import them from `knowledge_stores.py` and `responses.py`, or
+reuse them in your own scripts.
+
+Environment:
+    API_KEY               (required) your TwelveLabs API key
+    TWELVELABS_BASE_URL   (optional) override the API base URL. When unset the
+                          SDK default (prod, https://api.twelvelabs.io/v1.3) is used.
+"""
+
+import os
+import time
+import uuid
+from typing import Dict, NamedTuple, Optional
+
+from twelvelabs import TwelveLabs
+from twelvelabs.types import AssetDetail, KnowledgeStore
+
+
+class KnowledgeStoreSetup(NamedTuple):
+    knowledge_store: KnowledgeStore
+    items: Dict[str, str]  # {"video": item_id, "image": item_id}
+
+ASSETS_DIR = os.path.join(os.path.dirname(__file__), "assets")
+VIDEO_PATH = os.path.join(ASSETS_DIR, "example.mp4")
+IMAGE_PATH = os.path.join(ASSETS_DIR, "search_sample.png")
+
+# A small, reliably-reachable public sample used for the `method="url"` path.
+PUBLIC_VIDEO_URL = (
+    "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+)
+
+
+def make_client() -> TwelveLabs:
+    """Build a client from API_KEY (+ optional TWELVELABS_BASE_URL)."""
+    api_key = os.getenv("API_KEY")
+    assert api_key, "Set your API key in an environment variable named API_KEY."
+    base_url = os.getenv("TWELVELABS_BASE_URL")
+    if base_url:
+        return TwelveLabs(api_key=api_key, base_url=base_url)
+    return TwelveLabs(api_key=api_key)
+
+
+def create_asset_from_file(client: TwelveLabs, path: str, **kwargs) -> str:
+    """Upload a local file as an asset (method='direct'). Returns the asset id."""
+    with open(path, "rb") as f:
+        asset = client.assets.create(method="direct", file=f, **kwargs)
+    print(f"  Created asset (direct): id={asset.id} from {os.path.basename(path)}")
+    return asset.id
+
+
+def create_asset_from_url(client: TwelveLabs, url: str, **kwargs) -> str:
+    """Create an asset from a public URL (method='url'). Returns the asset id."""
+    asset = client.assets.create(method="url", url=url, **kwargs)
+    print(f"  Created asset (url): id={asset.id}")
+    return asset.id
+
+
+def wait_for_asset_ready(
+    client: TwelveLabs, asset_id: str, timeout: float = 600, interval: float = 5
+) -> AssetDetail:
+    """Poll an asset until it reaches a terminal status (ready/failed)."""
+    deadline = time.time() + timeout
+    while True:
+        asset = client.assets.retrieve(asset_id=asset_id)
+        if asset.status in ("ready", "failed"):
+            print(f"  Asset {asset_id} status={asset.status}")
+            if asset.status == "failed":
+                raise RuntimeError(f"Asset {asset_id} failed to process")
+            return asset
+        if time.time() > deadline:
+            raise TimeoutError(f"Asset {asset_id} not ready after {timeout}s (status={asset.status})")
+        print(f"  Asset {asset_id} status={asset.status} ... waiting")
+        time.sleep(interval)
+
+
+def wait_for_item_ready(
+    client: TwelveLabs,
+    knowledge_store_id: str,
+    item_id: str,
+    timeout: float = 900,
+    interval: float = 10,
+):
+    """Poll a knowledge store item until it is ready (or fails / times out)."""
+    deadline = time.time() + timeout
+    while True:
+        item = client.knowledge_store_items.retrieve(
+            knowledge_store_id=knowledge_store_id, item_id=item_id
+        )
+        if item.status in ("ready", "failed"):
+            print(f"  Item {item_id} status={item.status}")
+            if item.status == "failed":
+                raise RuntimeError(f"Item {item_id} failed to process")
+            return item
+        if time.time() > deadline:
+            raise TimeoutError(f"Item {item_id} not ready after {timeout}s (status={item.status})")
+        print(f"  Item {item_id} status={item.status} ... waiting")
+        time.sleep(interval)
+
+
+def setup_ready_knowledge_store(
+    client: TwelveLabs,
+    name: Optional[str] = None,
+    ingestion_config=None,
+    add_video: bool = True,
+    add_image: bool = True,
+    wait: bool = True,
+) -> KnowledgeStoreSetup:
+    """Create a knowledge store, add a video and/or image item, and (optionally)
+    wait until the items are ready.
+
+    Returns a KnowledgeStoreSetup(knowledge_store=..., items={"video": id, ...}).
+    """
+    name = name or f"ks-example-{uuid.uuid4()}"
+    ks: KnowledgeStore = client.knowledge_stores.create(
+        name=name, ingestion_config=ingestion_config
+    )
+    print(f"Created knowledge store: id={ks.id} name={ks.name}")
+
+    items: Dict[str, str] = {}
+
+    if add_video:
+        video_asset_id = create_asset_from_file(client, VIDEO_PATH)
+        wait_for_asset_ready(client, video_asset_id)
+        video_item = client.knowledge_store_items.create(
+            knowledge_store_id=ks.id, asset_id=video_asset_id, asset_type="video"
+        )
+        items["video"] = video_item.id
+        print(f"  Added video item: id={video_item.id}")
+
+    if add_image:
+        image_asset_id = create_asset_from_file(client, IMAGE_PATH)
+        wait_for_asset_ready(client, image_asset_id)
+        image_item = client.knowledge_store_items.create(
+            knowledge_store_id=ks.id, asset_id=image_asset_id, asset_type="image"
+        )
+        items["image"] = image_item.id
+        print(f"  Added image item: id={image_item.id}")
+
+    if wait:
+        for kind, item_id in items.items():
+            print(f"Waiting for {kind} item {item_id} to be ready ...")
+            wait_for_item_ready(client, ks.id, item_id)
+
+    return KnowledgeStoreSetup(knowledge_store=ks, items=items)
+
+
+def cleanup_knowledge_store(client: TwelveLabs, knowledge_store_id: str) -> None:
+    """Delete a knowledge store (and all its items). Best-effort."""
+    try:
+        client.knowledge_stores.delete(knowledge_store_id=knowledge_store_id)
+        print(f"Deleted knowledge store {knowledge_store_id}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  (cleanup) failed to delete {knowledge_store_id}: {exc}")

--- a/examples/knowledge_stores.py
+++ b/examples/knowledge_stores.py
@@ -1,0 +1,313 @@
+"""Knowledge store examples: assets, stores, items, item collections, and search.
+
+Covers, end to end:
+  - creating a knowledge store with each ingestion_config variant
+    (none / description enrichment / json_schema enrichment)
+  - knowledge store CRUD (create, retrieve, update, list, delete)
+  - adding assets as items and polling until ready
+  - listing / filtering items by status
+  - item collections (create, add items, list, remove, update, delete)
+  - search: default, group_by=item, asset_type filter, item_id filter,
+    modality options, include_metadata, and pagination
+
+Run:
+    source env/bin/activate
+    python examples/knowledge_stores.py
+"""
+
+import uuid
+
+from twelvelabs import (
+    AssetTypeFilter,
+    EnrichmentConfig_Description,
+    EnrichmentConfig_JsonSchema,
+    EnrichmentConfigJsonSchemaJsonSchema,
+    IngestionConfig,
+    ItemIdFilter,
+    KnowledgeStoreSearchQuery,
+    SearchKnowledgeStoreFilter,
+    SearchKnowledgeStoreOptions,
+    VideoSearchOptions,
+)
+
+from _ks_helpers import (
+    cleanup_knowledge_store,
+    make_client,
+    setup_ready_knowledge_store,
+)
+
+
+def print_search_response(resp, label):
+    print(f"\n[{label}] {len(resp.data)} result(s); "
+          f"next_page_token={'set' if resp.next_page_token else 'none'}")
+    for hit in resp.data:
+        if hit.asset_type == "video":
+            print(f"  video rank={hit.rank} item={hit.item_id} matches={len(hit.matches)}")
+            for m in hit.matches[:3]:
+                print(f"    {m.start_sec:.1f}-{m.end_sec:.1f}s modalities={m.modalities}")
+        else:
+            print(f"  image rank={hit.rank} item={hit.item_id}")
+        if hit.metadata is not None:
+            print(f"    metadata={hit.metadata}")
+
+
+def demo_ingestion_config_variants(client):
+    """Create a KS with each ingestion_config variant. ingestion_config is
+    immutable after creation, so each variant needs its own store."""
+    print("\n=== Ingestion config variants ===")
+
+    # 1) No ingestion config.
+    ks_plain = client.knowledge_stores.create(
+        name=f"ks-plain-{uuid.uuid4()}",
+        description="No enrichment config",
+        metadata={"team": "qa", "purpose": "sdk-test"},
+    )
+    print(f"  plain: id={ks_plain.id} metadata={ks_plain.metadata}")
+
+    # 2) Description-based enrichment.
+    ks_desc = client.knowledge_stores.create(
+        name=f"ks-desc-{uuid.uuid4()}",
+        ingestion_config=IngestionConfig(
+            enrichment_config=EnrichmentConfig_Description(
+                description="Extract the main subject, setting, and mood of each shot."
+            )
+        ),
+    )
+    print(f"  description-enrichment: id={ks_desc.id}")
+
+    # 3) JSON-schema enrichment. Note the platform's schema restrictions:
+    #    root type must be object, every property needs a description, no
+    #    nullable / composition / $ref keywords.
+    ks_schema = client.knowledge_stores.create(
+        name=f"ks-schema-{uuid.uuid4()}",
+        ingestion_config=IngestionConfig(
+            enrichment_config=EnrichmentConfig_JsonSchema(
+                json_schema=EnrichmentConfigJsonSchemaJsonSchema(
+                    type="object",
+                    properties={
+                        "subject": {
+                            "type": "string",
+                            "description": "The primary subject visible in the shot.",
+                        },
+                        "setting": {
+                            "type": "string",
+                            "description": "Where the shot takes place.",
+                        },
+                    },
+                )
+            )
+        ),
+    )
+    print(f"  json-schema-enrichment: id={ks_schema.id}")
+
+    for ks in (ks_plain, ks_desc, ks_schema):
+        cleanup_knowledge_store(client, ks.id)
+
+
+def demo_crud(client):
+    print("\n=== Knowledge store CRUD ===")
+    ks = client.knowledge_stores.create(name=f"ks-crud-{uuid.uuid4()}")
+    print(f"  created: id={ks.id} name={ks.name}")
+
+    retrieved = client.knowledge_stores.retrieve(knowledge_store_id=ks.id)
+    print(f"  retrieved: id={retrieved.id} item_count={retrieved.item_count}")
+
+    updated = client.knowledge_stores.update(
+        knowledge_store_id=ks.id,
+        name=f"ks-crud-updated-{uuid.uuid4()}",
+        description="Updated description",
+        metadata={"stage": "updated"},
+    )
+    print(f"  updated: name={updated.name} description={updated.description} metadata={updated.metadata}")
+
+    # list() returns an auto-paginating SyncPager (consistent with
+    # assets.list() / indexes.list()); iterate it directly.
+    print("  listing knowledge stores (first few):")
+    for i, item in enumerate(client.knowledge_stores.list(page_limit=5)):
+        print(f"    id={item.id} name={item.name} item_count={item.item_count}")
+        if i >= 4:
+            break
+
+    cleanup_knowledge_store(client, ks.id)
+
+
+def demo_items(client, ks_id, items):
+    print("\n=== Items ===")
+    print("  list all items:")
+    for it in client.knowledge_store_items.list(
+        knowledge_store_id=ks_id, page_limit=50, sort_by="created_at", sort_option="desc"
+    ):
+        print(f"    id={it.id} type={it.asset_type} status={it.status}")
+
+    print("  filter items by status=ready:")
+    ready = list(client.knowledge_store_items.list(
+        knowledge_store_id=ks_id, status=["ready"]
+    ))
+    print(f"    {len(ready)} ready item(s)")
+
+    # Retrieve a single item.
+    any_item_id = next(iter(items.values()))
+    single = client.knowledge_store_items.retrieve(
+        knowledge_store_id=ks_id, item_id=any_item_id
+    )
+    print(f"  retrieved item {single.id}: type={single.asset_type} "
+          f"system_metadata={single.system_metadata is not None}")
+
+
+def demo_item_collections(client, ks_id, items):
+    print("\n=== Item collections ===")
+    collection = client.knowledge_store_item_collections.create(
+        knowledge_store_id=ks_id,
+        name=f"collection-{uuid.uuid4()}",
+        description="A subset of items",
+        metadata={"group": "highlights"},
+    )
+    print(f"  created collection: id={collection.id} name={collection.name}")
+
+    all_item_ids = list(items.values())
+    client.knowledge_store_item_collections.add_items(
+        knowledge_store_id=ks_id, collection_id=collection.id, item_ids=all_item_ids
+    )
+    print(f"  added {len(all_item_ids)} item(s) to collection")
+
+    members = list(client.knowledge_store_item_collections.list_items(
+        knowledge_store_id=ks_id, collection_id=collection.id
+    ))
+    print(f"  collection now has {len(members)} member item(s)")
+
+    updated = client.knowledge_store_item_collections.update(
+        knowledge_store_id=ks_id, collection_id=collection.id, description="Updated collection description"
+    )
+    print(f"  updated collection description={updated.description}")
+
+    if all_item_ids:
+        client.knowledge_store_item_collections.remove_items(
+            knowledge_store_id=ks_id, collection_id=collection.id, item_ids=[all_item_ids[0]]
+        )
+        print(f"  removed 1 item from collection")
+
+    print("  listing collections:")
+    for c in client.knowledge_store_item_collections.list(knowledge_store_id=ks_id):
+        print(f"    id={c.id} name={c.name}")
+
+    client.knowledge_store_item_collections.delete(
+        knowledge_store_id=ks_id, collection_id=collection.id
+    )
+    print(f"  deleted collection {collection.id}")
+
+
+def demo_search(client, ks_id, items):
+    print("\n=== Search ===")
+
+    # NOTE: the spec/SDK document `search_options` as optional (videos default
+    # to visual matching when omitted), but the deployed API (both prod and dev
+    # as of this writing) returns 400 "The search_options parameter is required
+    # but was not provided" when it is omitted. Every call below therefore passes
+    # search_options explicitly.
+    visual_only = SearchKnowledgeStoreOptions(
+        video=VideoSearchOptions(modalities=["visual"])
+    )
+
+    # 1) Basic search (individual matches).
+    resp = client.knowledge_stores.search(
+        knowledge_store_id=ks_id,
+        query=KnowledgeStoreSearchQuery(text="a person or animal moving"),
+        search_options=visual_only,
+    )
+    print_search_response(resp, "basic (visual)")
+
+    # 2) group_by=item.
+    resp = client.knowledge_stores.search(
+        knowledge_store_id=ks_id,
+        query=KnowledgeStoreSearchQuery(text="a person or animal moving"),
+        search_options=visual_only,
+        group_by="item",
+    )
+    print_search_response(resp, "group_by=item")
+
+    # 3) Filter by asset_type = video, with multi-modality search options.
+    resp = client.knowledge_stores.search(
+        knowledge_store_id=ks_id,
+        query=KnowledgeStoreSearchQuery(text="dialogue or narration"),
+        filter=SearchKnowledgeStoreFilter(asset_type=AssetTypeFilter(eq="video")),
+        search_options=SearchKnowledgeStoreOptions(
+            video=VideoSearchOptions(
+                modalities=["visual", "audio"],
+            )
+        ),
+        include_metadata=True,
+    )
+    print_search_response(resp, "video-only + all modalities + metadata")
+
+    # 4) Filter by specific item id.
+    if "video" in items:
+        resp = client.knowledge_stores.search(
+            knowledge_store_id=ks_id,
+            query=KnowledgeStoreSearchQuery(text="anything"),
+            filter=SearchKnowledgeStoreFilter(item_id=ItemIdFilter(in_=[items["video"]])),
+            search_options=visual_only,
+        )
+        print_search_response(resp, f"item_id in [{items['video']}]")
+
+    # 5) Pagination with small page_size.
+    # NOTES on cursor pagination across environments:
+    #  - prod (as of this writing) does NOT return a next_page_token on a
+    #    truncated page, so the page-2 branch is simply skipped there.
+    #  - where cursor pagination is available (e.g. dev), a truncated page does
+    #    return a token, but fetching the next page can currently fail to
+    #    deserialize: the server may omit `modalities` on a match while the SDK
+    #    marks VideoMatch.modalities as required, raising a pydantic
+    #    ValidationError. The page-2 fetch is therefore guarded so this example
+    #    degrades gracefully instead of crashing.
+    resp = client.knowledge_stores.search(
+        knowledge_store_id=ks_id,
+        query=KnowledgeStoreSearchQuery(text="a person or animal moving"),
+        search_options=visual_only,
+        page_size=1,
+    )
+    print_search_response(resp, "page_size=1")
+    if resp.next_page_token:
+        try:
+            page2 = client.knowledge_stores.search(
+                knowledge_store_id=ks_id,
+                query=KnowledgeStoreSearchQuery(text="a person or animal moving"),
+                search_options=visual_only,
+                page_size=1,
+                page_token=resp.next_page_token,
+            )
+            print_search_response(page2, "page 2 (via next_page_token)")
+        except Exception as exc:  # noqa: BLE001
+            print(f"  page 2 fetch failed to deserialize: {type(exc).__name__} "
+                  f"(likely a match missing the required `modalities` field)")
+
+
+def main():
+    with make_client() as client:
+        # Lightweight demos that don't need ready items.
+        demo_ingestion_config_variants(client)
+        demo_crud(client)
+
+        # Full flow: create a store with a ready video, then exercise items,
+        # collections, and search against it.
+        #
+        # NOTE on image items (asset_type="image"), as of this writing:
+        #  - prod rejects them with 422 "The asset_type parameter is invalid".
+        #  - dev accepts the create call, but the image can stay `queued` for a
+        #    long time (image ingestion lag), so waiting for `ready` may time out.
+        # Kept video-only here so the example runs cleanly everywhere. Set
+        # add_image=True on an environment where image items are fully supported.
+        setup = setup_ready_knowledge_store(
+            client, name=f"ks-search-{uuid.uuid4()}", add_image=False
+        )
+        ks = setup.knowledge_store
+        items = setup.items
+        try:
+            demo_items(client, ks.id, items)
+            demo_item_collections(client, ks.id, items)
+            demo_search(client, ks.id, items)
+        finally:
+            cleanup_knowledge_store(client, ks.id)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/knowledge_stores.py
+++ b/examples/knowledge_stores.py
@@ -31,9 +31,13 @@ from twelvelabs import (
 )
 
 from _ks_helpers import (
+    IMAGE_PATH,
+    VIDEO_PATH,
     cleanup_knowledge_store,
+    create_asset_from_file,
     make_client,
-    setup_ready_knowledge_store,
+    wait_for_asset_ready,
+    wait_for_item_ready,
 )
 
 
@@ -131,8 +135,33 @@ def demo_crud(client):
     cleanup_knowledge_store(client, ks.id)
 
 
-def demo_items(client, ks_id, items):
+def demo_items(client, ks_id):
     print("\n=== Items ===")
+    items = {}
+
+    # Add a video and an image to the knowledge store. Upload each file as an
+    # asset, wait for it to be ready, then create a knowledge store item from it.
+    video_asset_id = create_asset_from_file(client, VIDEO_PATH)
+    wait_for_asset_ready(client, video_asset_id)
+    video_item = client.knowledge_store_items.create(
+        knowledge_store_id=ks_id, asset_id=video_asset_id, asset_type="video"
+    )
+    items["video"] = video_item.id
+    print(f"  created video item: id={video_item.id}")
+
+    image_asset_id = create_asset_from_file(client, IMAGE_PATH)
+    wait_for_asset_ready(client, image_asset_id)
+    image_item = client.knowledge_store_items.create(
+        knowledge_store_id=ks_id, asset_id=image_asset_id, asset_type="image"
+    )
+    items["image"] = image_item.id
+    print(f"  created image item: id={image_item.id}")
+
+    # Wait for both items to finish processing.
+    for kind, item_id in items.items():
+        print(f"  waiting for {kind} item {item_id} to be ready ...")
+        wait_for_item_ready(client, ks_id, item_id)
+
     print("  list all items:")
     for it in client.knowledge_store_items.list(
         knowledge_store_id=ks_id, page_limit=50, sort_by="created_at", sort_option="desc"
@@ -146,12 +175,13 @@ def demo_items(client, ks_id, items):
     print(f"    {len(ready)} ready item(s)")
 
     # Retrieve a single item.
-    any_item_id = next(iter(items.values()))
     single = client.knowledge_store_items.retrieve(
-        knowledge_store_id=ks_id, item_id=any_item_id
+        knowledge_store_id=ks_id, item_id=items["video"]
     )
     print(f"  retrieved item {single.id}: type={single.asset_type} "
           f"system_metadata={single.system_metadata is not None}")
+
+    return items
 
 
 def demo_item_collections(client, ks_id, items):
@@ -199,11 +229,7 @@ def demo_item_collections(client, ks_id, items):
 def demo_search(client, ks_id, items):
     print("\n=== Search ===")
 
-    # NOTE: the spec/SDK document `search_options` as optional (videos default
-    # to visual matching when omitted), but the deployed API (both prod and dev
-    # as of this writing) returns 400 "The search_options parameter is required
-    # but was not provided" when it is omitted. Every call below therefore passes
-    # search_options explicitly.
+    # `search_options` selects which video modalities to match on.
     visual_only = SearchKnowledgeStoreOptions(
         video=VideoSearchOptions(modalities=["visual"])
     )
@@ -249,16 +275,7 @@ def demo_search(client, ks_id, items):
         )
         print_search_response(resp, f"item_id in [{items['video']}]")
 
-    # 5) Pagination with small page_size.
-    # NOTES on cursor pagination across environments:
-    #  - prod (as of this writing) does NOT return a next_page_token on a
-    #    truncated page, so the page-2 branch is simply skipped there.
-    #  - where cursor pagination is available (e.g. dev), a truncated page does
-    #    return a token, but fetching the next page can currently fail to
-    #    deserialize: the server may omit `modalities` on a match while the SDK
-    #    marks VideoMatch.modalities as required, raising a pydantic
-    #    ValidationError. The page-2 fetch is therefore guarded so this example
-    #    degrades gracefully instead of crashing.
+    # 5) Paginate with a small page_size, then fetch the next page with the token.
     resp = client.knowledge_stores.search(
         knowledge_store_id=ks_id,
         query=KnowledgeStoreSearchQuery(text="a person or animal moving"),
@@ -267,18 +284,14 @@ def demo_search(client, ks_id, items):
     )
     print_search_response(resp, "page_size=1")
     if resp.next_page_token:
-        try:
-            page2 = client.knowledge_stores.search(
-                knowledge_store_id=ks_id,
-                query=KnowledgeStoreSearchQuery(text="a person or animal moving"),
-                search_options=visual_only,
-                page_size=1,
-                page_token=resp.next_page_token,
-            )
-            print_search_response(page2, "page 2 (via next_page_token)")
-        except Exception as exc:  # noqa: BLE001
-            print(f"  page 2 fetch failed to deserialize: {type(exc).__name__} "
-                  f"(likely a match missing the required `modalities` field)")
+        page2 = client.knowledge_stores.search(
+            knowledge_store_id=ks_id,
+            query=KnowledgeStoreSearchQuery(text="a person or animal moving"),
+            search_options=visual_only,
+            page_size=1,
+            page_token=resp.next_page_token,
+        )
+        print_search_response(page2, "page 2 (via next_page_token)")
 
 
 def main():
@@ -287,22 +300,12 @@ def main():
         demo_ingestion_config_variants(client)
         demo_crud(client)
 
-        # Full flow: create a store with a ready video, then exercise items,
-        # collections, and search against it.
-        #
-        # NOTE on image items (asset_type="image"), as of this writing:
-        #  - prod rejects them with 422 "The asset_type parameter is invalid".
-        #  - dev accepts the create call, but the image can stay `queued` for a
-        #    long time (image ingestion lag), so waiting for `ready` may time out.
-        # Kept video-only here so the example runs cleanly everywhere. Set
-        # add_image=True on an environment where image items are fully supported.
-        setup = setup_ready_knowledge_store(
-            client, name=f"ks-search-{uuid.uuid4()}", add_image=False
-        )
-        ks = setup.knowledge_store
-        items = setup.items
+        # Full flow: create a store, add a video and an image item, then
+        # exercise items, collections, and search against it.
+        ks = client.knowledge_stores.create(name=f"ks-search-{uuid.uuid4()}")
+        print(f"\nCreated knowledge store: id={ks.id} name={ks.name}")
         try:
-            demo_items(client, ks.id, items)
+            items = demo_items(client, ks.id)
             demo_item_collections(client, ks.id, items)
             demo_search(client, ks.id, items)
         finally:

--- a/examples/responses.py
+++ b/examples/responses.py
@@ -38,11 +38,10 @@ from _ks_helpers import (
 
 
 def create_response(client, **kwargs):
-    """Wrapper around responses.create_response that retries on HTTP 429.
+    """Wrapper around responses.create that retries on HTTP 429.
 
-    The /responses endpoint is rate-limited (observed: ~4 requests/minute), so
-    a script that fires several calls in a row will get a 429. This honors the
-    `retry-after` header and retries.
+    The /responses endpoint is rate-limited, so a script that fires several
+    calls in a row may get a 429. This honors the `retry-after` header and retries.
     """
     while True:
         try:
@@ -223,9 +222,8 @@ def demo_streaming(client, ks_id):
     text as they arrive.
     """
     print("\n[streaming] responses.create_stream():")
-    # NOTE: create_stream() is lazy — the request (and any 429) fires when the
-    # iterator is first consumed, not at the call. So the whole create+consume
-    # is wrapped in the 429 retry.
+    # create_stream() is lazy: the request fires when the iterator is first
+    # consumed, not at the call, so the whole create+consume is wrapped in the retry.
     while True:
         try:
             text_parts = []
@@ -260,11 +258,9 @@ def demo_streaming(client, ks_id):
 
 def main():
     with make_client() as client:
-        # video-only: image items (asset_type="image") are rejected on prod and
-        # process slowly on dev as of this writing. Set add_image=True where
-        # image items are fully supported.
+        # Create a knowledge store with a ready video and image item to reason over.
         setup = setup_ready_knowledge_store(
-            client, name=f"ks-responses-{uuid.uuid4()}", add_image=False
+            client, name=f"ks-responses-{uuid.uuid4()}"
         )
         ks = setup.knowledge_store
         items = setup.items

--- a/examples/responses.py
+++ b/examples/responses.py
@@ -1,0 +1,284 @@
+"""Responses API examples over a knowledge store.
+
+Covers:
+  - non-streaming response
+  - streaming response (SSE)
+  - structured output (text.format = json_schema)
+  - selections targeting a single item ({{sel:N}} tokens)
+  - selections targeting an item collection
+  - multi-turn conversation via session_id
+  - include=["intermediate_outputs"]
+
+Streaming uses responses.create_stream(), which returns an iterator of typed
+ResponseStreamEvent objects (see `demo_streaming`).
+
+Run:
+    source env/bin/activate
+    python examples/responses.py
+"""
+
+import json
+import time
+import uuid
+
+from twelvelabs import (
+    ResponseInputItem,
+    ResponseSelection,
+    TextParam,
+)
+from twelvelabs.core.api_error import ApiError
+from twelvelabs.types.text_param_format import TextParamFormat_JsonSchema
+
+from _ks_helpers import (
+    cleanup_knowledge_store,
+    make_client,
+    setup_ready_knowledge_store,
+)
+
+
+
+def create_response(client, **kwargs):
+    """Wrapper around responses.create_response that retries on HTTP 429.
+
+    The /responses endpoint is rate-limited (observed: ~4 requests/minute), so
+    a script that fires several calls in a row will get a 429. This honors the
+    `retry-after` header and retries.
+    """
+    while True:
+        try:
+            return client.responses.create(**kwargs)
+        except ApiError as exc:
+            if getattr(exc, "status_code", None) == 429:
+                headers = getattr(exc, "headers", {}) or {}
+                wait = int(headers.get("retry-after", "15")) + 1
+                print(f"  [rate limited] waiting {wait}s then retrying ...")
+                time.sleep(wait)
+                continue
+            raise
+
+
+def print_response(resp, label):
+    print(f"\n[{label}]")
+    print(f"  id={resp.id} session_id={resp.session_id} status={resp.status}")
+    if resp.usage is not None:
+        print(f"  usage: input={resp.usage.input_tokens} output={resp.usage.output_tokens}")
+    for item in resp.output or []:
+        if item.content:
+            for part in item.content:
+                text = (part.text or "").strip()
+                if text:
+                    print(f"  [{item.type}] {text[:400]}")
+        elif item.type == "function_call":
+            print(f"  [function_call] name={item.name} args={item.arguments}")
+
+
+def demo_non_streaming(client, ks_id):
+    resp = create_response(
+        client,
+        knowledge_store_id=ks_id,
+        input=[
+            ResponseInputItem(
+                type="message",
+                role="user",
+                content="Summarize what happens in this knowledge store in two sentences.",
+            )
+        ],
+    )
+    print_response(resp, "non-streaming")
+    return resp.session_id
+
+
+def demo_multi_turn(client, ks_id, session_id):
+    """Continue the conversation started in demo_non_streaming."""
+    if not session_id:
+        print("\n[multi-turn] skipped (no session_id from previous turn)")
+        return
+    resp = create_response(
+        client,
+        knowledge_store_id=ks_id,
+        session_id=session_id,
+        input=[
+            ResponseInputItem(
+                type="message",
+                role="user",
+                content="Now list the three most important moments as bullet points.",
+            )
+        ],
+    )
+    print_response(resp, "multi-turn (same session)")
+
+
+def demo_include_intermediate(client, ks_id):
+    resp = create_response(
+        client,
+        knowledge_store_id=ks_id,
+        input=[
+            ResponseInputItem(
+                type="message",
+                role="user",
+                content="What is the overall mood, and how did you decide?",
+            )
+        ],
+        include=["intermediate_outputs"],
+    )
+    print_response(resp, "include=intermediate_outputs")
+
+
+def demo_structured_output(client, ks_id):
+    resp = create_response(
+        client,
+        knowledge_store_id=ks_id,
+        input=[
+            ResponseInputItem(
+                type="message",
+                role="user",
+                content="Extract a title and a list of up to 3 tags for this content.",
+            )
+        ],
+        text=TextParam(
+            format=TextParamFormat_JsonSchema(
+                name="content_summary",
+                description="A short structured summary of the knowledge store content.",
+                schema_={
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "A short title."},
+                        "tags": {
+                            "type": "array",
+                            "description": "Up to three descriptive tags.",
+                            "items": {"type": "string", "description": "A single tag."},
+                        },
+                    },
+                    "required": ["title", "tags"],
+                    "additionalProperties": False,
+                },
+                strict=True,
+            )
+        ),
+    )
+    print_response(resp, "structured output (json_schema)")
+    # The final message text should be a JSON string conforming to the schema.
+    for item in resp.output or []:
+        for part in item.content or []:
+            if part.text:
+                try:
+                    parsed = json.loads(part.text)
+                    print(f"  parsed JSON: {parsed}")
+                except json.JSONDecodeError:
+                    print("  (final text was not valid JSON)")
+
+
+def demo_selections_item(client, ks_id, items):
+    """Restrict the request to a single item and reference it with {{sel:0}}."""
+    if "video" not in items:
+        print("\n[selections:item] skipped (no video item)")
+        return
+    resp = create_response(
+        client,
+        knowledge_store_id=ks_id,
+        input=[
+            ResponseInputItem(
+                type="message",
+                role="user",
+                content="Describe {{sel:0}} in one sentence.",
+            )
+        ],
+        selections=[ResponseSelection(kind="item", id=items["video"])],
+    )
+    print_response(resp, "selections -> single item ({{sel:0}})")
+
+
+def demo_selections_collection(client, ks_id, items):
+    """Create a collection, then restrict a response to it via {{sel:0}}."""
+    collection = client.knowledge_store_item_collections.create(
+        knowledge_store_id=ks_id, name=f"resp-collection-{uuid.uuid4()}"
+    )
+    client.knowledge_store_item_collections.add_items(
+        knowledge_store_id=ks_id, collection_id=collection.id, item_ids=list(items.values())
+    )
+    print(f"\n  created collection {collection.id} with {len(items)} item(s)")
+    resp = create_response(
+        client,
+        knowledge_store_id=ks_id,
+        input=[
+            ResponseInputItem(
+                type="message",
+                role="user",
+                content="Summarize the contents of {{sel:0}}.",
+            )
+        ],
+        selections=[ResponseSelection(kind="collection", id=collection.id)],
+    )
+    print_response(resp, "selections -> collection ({{sel:0}})")
+    client.knowledge_store_item_collections.delete(
+        knowledge_store_id=ks_id, collection_id=collection.id
+    )
+
+
+def demo_streaming(client, ks_id):
+    """Stream a response as Server-Sent Events via responses.create_stream(),
+    which returns an iterator of typed ResponseStreamEvent objects.
+
+    Assembles the incremental `response.output_text.delta` chunks into the final
+    text as they arrive.
+    """
+    print("\n[streaming] responses.create_stream():")
+    # NOTE: create_stream() is lazy — the request (and any 429) fires when the
+    # iterator is first consumed, not at the call. So the whole create+consume
+    # is wrapped in the 429 retry.
+    while True:
+        try:
+            text_parts = []
+            event_count = 0
+            for event in client.responses.create_stream(
+                knowledge_store_id=ks_id,
+                input=[
+                    ResponseInputItem(
+                        type="message",
+                        role="user",
+                        content="Give a one-sentence summary.",
+                    )
+                ],
+            ):
+                event_count += 1
+                etype = getattr(event, "type", None)
+                if etype == "response.output_text.delta":
+                    text_parts.append(getattr(event, "delta", "") or "")
+                elif etype == "response.completed":
+                    print("  received response.completed")
+            break
+        except ApiError as exc:
+            if getattr(exc, "status_code", None) == 429:
+                wait = int((getattr(exc, "headers", {}) or {}).get("retry-after", "15")) + 1
+                print(f"  [rate limited] waiting {wait}s then retrying ...")
+                time.sleep(wait)
+                continue
+            raise
+    print(f"  streamed {event_count} event(s)")
+    print(f"  assembled text: {''.join(text_parts)[:400]}")
+
+
+def main():
+    with make_client() as client:
+        # video-only: image items (asset_type="image") are rejected on prod and
+        # process slowly on dev as of this writing. Set add_image=True where
+        # image items are fully supported.
+        setup = setup_ready_knowledge_store(
+            client, name=f"ks-responses-{uuid.uuid4()}", add_image=False
+        )
+        ks = setup.knowledge_store
+        items = setup.items
+        try:
+            session_id = demo_non_streaming(client, ks.id)
+            demo_multi_turn(client, ks.id, session_id)
+            demo_include_intermediate(client, ks.id)
+            demo_structured_output(client, ks.id)
+            demo_selections_item(client, ks.id, items)
+            demo_selections_collection(client, ks.id, items)
+            demo_streaming(client, ks.id)
+        finally:
+            cleanup_knowledge_store(client, ks.id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds runnable **knowledge stores + responses (Agents API)** examples.

- **`examples/`:** `knowledge_stores.py`, `responses.py`, `_ks_helpers.py` — KS CRUD, items (video **and** image), item collections, search (incl. `include_metadata`), and responses (non-streaming, multi-turn, `intermediate_outputs`, structured JSON, selections, streaming).
- **No client change needed:** the exported `TwelveLabs` is the full generated `BaseClient`, which already binds `knowledge_stores`, `knowledge_store_items`, `knowledge_store_item_collections`, and `responses` (this is the TS-only gap tracked in VCS-2459).

## Verification (live, prod)

Verified against the 1.3.0 generated client:
- `knowledge_stores.py` — full run green: video+image item creation, list/filter/retrieve, collections, search, `include_metadata` deserializes (`VideoSearchSystemMetadata(duration, width, height, size)`), page-2 pagination.
- `responses.py` — full run green: all modes incl. streaming (119 events), structured JSON parsed, selections over item + collection.

## ⚠️ Do not merge to `main` as-is — sequence with the 1.3.0 release

This branch is cut from `main` (SDK 1.2.9), which does not yet contain the `knowledge_stores`/`responses` clients. The examples import those resources, so they require the **1.3.0** release. Intended flow:

1. Land the 1.3.0 Fern regen (adds the generated clients).
2. Cherry-pick / rebase this branch onto it (touches only `.fernignore`'d `examples/` — no conflicts).
3. Merge → publish `1.3.0`.

Draft until the regen is available. `examples/` is repo-only (not shipped in the published package), so timing is flexible.

Refs: VCS-2460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
