### PR TITLE
Restructure README into Search and Analyze sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,63 +49,31 @@ pip install twelvelabs
 
 # Use the SDK
 
-To get started with the SDK, follow these basic steps:
+Upload your video, then follow the section for your task: search or analyze. See [our documentation](https://docs.twelvelabs.io/docs) for the complete list of features the platform provides.
 
-1. Create an index.
-2. Upload videos.
-3. Perform downstream tasks, such as searching or analyzing videos to generate text based on their content.
-
-## Create an index
-
-Indexes store and organize your video data, allowing you to group related videos. When you create an index, configure which video understanding models process your videos and what modalities those models analyze.
-
-To create an index, call the `client.indexes.create` method with the following parameters:
-
-- **`index_name`**: The name of the index.
-- **`models`**: An array of models to enable. Each entry has two fields:
-  - **`model_name`**: The model to enable. Use `"marengo3.0"` for search or `"pegasus1.2"` for text generation.
-  - **`model_options`**: The modalities to analyze.
-
-```py
-index = client.indexes.create(
-    index_name="<YOUR_INDEX_NAME>",
-    models=[
-        {"model_name": "marengo3.0", "model_options": ["visual", "audio"]},
-        {"model_name": "pegasus1.2", "model_options": ["visual", "audio"]}
-    ]
-)
-if not index.id:
-    raise RuntimeError("Failed to create an index.")
-print(f"Created index: id={index.id}")
-```
-
-The `client.indexes.create` method returns an object that includes, among other information, a field named `id` representing the unique identifier of your new index.
-
-See the [Indexes](https://docs.twelvelabs.io/docs/concepts/indexes) page for more details.
-
-## Upload videos
+## Upload a video
 
 To upload a video, call the `client.assets.create` method with the following parameters:
 
 - **`method`**: Upload method. Use `"url"` for publicly accessible URLs or `"direct"` for local files.
-- **`url`** or **`file`**: The video URL or an opened file object in binary read mode. Use direct links to raw media files. Hosting platform links and cloud storage sharing links are not supported.
+- **`url`** or **`file`**: The video URL or an opened file object in binary read mode.
 
 ```py
 asset = client.assets.create(
     method="url",
-    url="<YOUR_VIDEO_URL>"
+    url="<YOUR_VIDEO_URL>" # Use direct links to raw media files. Video hosting platforms and cloud storage sharing links are not supported
     # Or use method="direct" and file=open("<PATH_TO_VIDEO_FILE>", "rb") to upload a local file.
 )
 print(f"Created asset: id={asset.id}")
 ```
 
-The `client.assets.create` method returns an object that includes, among other information, a field named `id` representing the unique identifier of your asset. Use this identifier in subsequent steps.
+The `client.assets.create` method returns an object that includes, among other information, a field named `id` representing the unique identifier of your asset. Use this identifier in the sections that follow.
 
-## Check the status of the asset
+### Check the status of the asset
 
 You only need this step for files larger than 200 MB. The platform processes files up to 200 MB synchronously and sets the asset status to ready. For larger files, check the asset status until it is ready.
 
-To check the status of the asset, call the `client.assets.retrieve` method with the unique identifier of your asset as a paremeter:
+To check the status of the asset, call the `client.assets.retrieve` method with the unique identifier of your asset as a parameter:
 
 ```py
 print("Waiting for asset to be ready...")
@@ -119,9 +87,40 @@ while True:
     time.sleep(5)
 ```
 
-## Index your video
+## Search
 
-To index your video, call the `client.indexes.indexed_assets.create` method with the following parameters:
+Search finds matching moments within an index. Create an index, add your uploaded video to it, then run queries.
+
+### Create an index
+
+Indexes store and organize your video data, allowing you to group related videos. When you create an index, configure which Marengo model processes your videos and which modalities it analyzes.
+
+To create an index, call the `client.indexes.create` method with the following parameters:
+
+- **`index_name`**: The name of the index.
+- **`models`**: An array of models to enable. Each entry has two fields:
+  - **`model_name`**: The model to enable. Use `"marengo3.0"` for search.
+  - **`model_options`**: The modalities to analyze.
+
+```py
+index = client.indexes.create(
+    index_name="<YOUR_INDEX_NAME>",
+    models=[
+        {"model_name": "marengo3.0", "model_options": ["visual", "audio"]}
+    ]
+)
+if not index.id:
+    raise RuntimeError("Failed to create an index.")
+print(f"Created index: id={index.id}")
+```
+
+The `client.indexes.create` method returns an object that includes, among other information, a field named `id` representing the unique identifier of your new index.
+
+See the [Indexes](https://docs.twelvelabs.io/docs/concepts/indexes) page for more details.
+
+### Add your video to the index
+
+Add the video you uploaded to your index. Call the `client.indexes.indexed_assets.create` method with the following parameters:
 
 - **`index_id`**: The unique identifier of your index.
 - **`asset_id`**: The unique identifier of the asset to index.
@@ -136,7 +135,7 @@ print(f"Created indexed asset: id={indexed_asset.id}")
 
 The `client.indexes.indexed_assets.create` method returns an object that includes, among other information, a field named `id` representing the unique identifier of your indexed asset.
 
-## Monitor the indexing process
+### Monitor the indexing process
 
 The platform indexes videos asynchronously. To monitor the indexing process, call the `client.indexes.indexed_assets.retrieve` method with the following parameters:
 
@@ -161,15 +160,11 @@ while True:
     time.sleep(5)
 ```
 
-The `client.indexes.indexed_assets.retrieve` method returns an object that includes, among other information, a field named `status` representing the status of the indexing process. Poll this method until `status` is `"ready"` before performing downstream tasks.
+The `client.indexes.indexed_assets.retrieve` method returns an object that includes, among other information, a field named `status` representing the status of the indexing process. Poll this method until `status` is `"ready"` before you run queries.
 
-## Perform downstream tasks
+### Run a query
 
-The sections below show the most common downstream tasks. See [our documentation](https://docs.twelvelabs.io/docs) for the complete list of features the platform provides.
-
-### Search
-
-Use natural language, images, or both to find matching video segments. Search operates within a single index.
+Use natural language, images, or both to find matching video segments.
 
 **Text queries**
 
@@ -251,13 +246,15 @@ for i, clip in enumerate(search_results):
 
 The response is similar to that received when using text queries.
 
-### Analyze videos
+## Analyze videos
 
 The platform uses a multimodal approach to analyze video content, processing visuals, sounds, spoken words, and on-screen text. Use a custom prompt to generate summaries, extract insights, answer questions, or produce structured output.
 
+> **Migrating from Pegasus 1.2?** Pegasus 1.5 analyzes an asset directly and does not use an index or a `video_id`. For upgrade instructions, see the [Migrate from Pegasus 1.2 to Pegasus 1.5](https://docs.twelvelabs.io/v1.3/docs/get-started/migration-guide) guide.
+
 Note the following about using these methods:
 
-- The Pegasus model must be enabled for the index.
+- Pegasus 1.5 analyzes the asset you uploaded. You do not need an index.
 - Your prompts can be instructive or descriptive, or you can phrase them as questions.
 - The maximum length of a prompt is 2,000 tokens.
 
@@ -267,13 +264,17 @@ Streaming delivers text fragments in real-time. Use it for live transcription or
 
 To analyze a video with streaming responses, call the `client.analyze_stream` method with the following parameters:
 
-- **`video_id`**: The unique identifier of the indexed asset.
-- **`prompt`**: Guides text generation, and it can be instructive, descriptive, or a question. The maximum length is 2,000 tokens.
+- **`model_name`**: The model to use. Use `"pegasus1.5"`.
+- **`video`**: A `VideoContext_AssetId` object that identifies the asset to analyze. Set `asset_id` to the unique identifier of your asset.
+- **`prompt_v_2`**: An `AnalyzePromptV2` object. Set `input_text` to your prompt. The maximum length is 2,000 tokens.
 
 ```py
+from twelvelabs.types import VideoContext_AssetId, AnalyzePromptV2
+
 text_stream = client.analyze_stream(
-    video_id=indexed_asset.id,
-    prompt="<YOUR_PROMPT>"
+    model_name="pegasus1.5",
+    video=VideoContext_AssetId(asset_id=asset.id),
+    prompt_v_2=AnalyzePromptV2(input_text="<YOUR_PROMPT>")
 )
 for text in text_stream:
     if text.event_type == "text_generation":
@@ -287,9 +288,12 @@ The `client.analyze_stream` method returns a stream of objects. The `event_type`
 Non-streaming returns the complete text in a single response. Use it for reports or summaries where you need the full result at once. Call the `client.analyze` method with the same parameters as `client.analyze_stream`.
 
 ```py
+from twelvelabs.types import VideoContext_AssetId, AnalyzePromptV2
+
 result = client.analyze(
-    video_id=indexed_asset.id,
-    prompt="<YOUR_PROMPT>"
+    model_name="pegasus1.5",
+    video=VideoContext_AssetId(asset_id=asset.id),
+    prompt_v_2=AnalyzePromptV2(input_text="<YOUR_PROMPT>")
 )
 print(result.data)
 ```


### PR DESCRIPTION
The README taught one linear flow that mixed steps required for search with steps that analyze does not use, and its analyze examples used a retired model and a parameter that no longer works.

This splits the guide into two self-contained sections — **Search** and **Analyze videos** — over a shared upload step, updates the analyze examples to the current asset-based flow, removes the retired model, and links the upgrade guide.

Every method, parameter, and response field was verified against the current SDK.